### PR TITLE
Feature/pattern config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+config.json

--- a/bin/audiosort
+++ b/bin/audiosort
@@ -7,4 +7,5 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 }
 $app = new Symfony\Component\Console\Application('Audio Sort', '1.0.0');
 $app->add(new \pxgamer\AudioSort\SortCommand());
+$app->add(new \pxgamer\AudioSort\ConfigCommand());
 $app->run();

--- a/src/ConfigCommand.php
+++ b/src/ConfigCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace pxgamer\AudioSort;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class ConfigCommand
+ * @package pxgamer\AudioSort
+ */
+class ConfigCommand extends Command
+{
+    const PATH = __DIR__ . '/../config.json';
+    /**
+     * @var SymfonyStyle
+     */
+    public $oOutput;
+
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config')
+            ->setDescription('Add a config parameter to the config.json')
+            ->addArgument('item', InputArgument::REQUIRED)
+            ->addArgument('value', InputArgument::REQUIRED);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface   $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     * @throws \ErrorException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $item = $input->getArgument('item');
+        $value = $input->getArgument('value');
+
+        $this->oOutput = new SymfonyStyle($input, $output);
+
+        if (!file_exists(self::PATH)) {
+            file_put_contents(self::PATH, '{}');
+        }
+
+        $currentConfig = json_decode(file_get_contents(__DIR__ . '/../config.json'), true);
+        $currentConfig[$item] = $value;
+        file_put_contents(__DIR__ . '/../config.json', json_encode($currentConfig));
+    }
+}


### PR DESCRIPTION
This adds support for issue #1.

- Adds a new `audiosort config` command for setting values in the `config.json`.
- Adds a new option `-p/--pattern` for specifying a pattern in the `sort` command

__Copy of #2 as I PR'd to the master branch.__